### PR TITLE
feat: add devenv plugin for QA skills and codespace definitions

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,2 +1,3 @@
 plugins:
   - github.com/nodeselector/dotfiles.private
+  - github.com/nodeselector/devenv


### PR DESCRIPTION
Adds [`nodeselector/devenv`](https://github.com/nodeselector/devenv) as a punch plugin.

This repo contains:
- Copilot skills for Actions codespace devloop operations
- QA scripts
- Codespace definitions
- A `dot.yaml` that installs skills to `~/.copilot/skills/`

After merging, run `./script/bootstrap` (or `script/clone-plugins`) to clone the plugin.