### PR TITLE
feat: add devenv plugin

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,2 +1,3 @@
 plugins:
   - github.com/nodeselector/dotfiles.private
+  - github.com/nodeselector/devenv


### PR DESCRIPTION
Adds `nodeselector/devenv` as a punch plugin.