### PR TITLE
feat(nvim): add branch diff file picker with delta preview

### DIFF
--- a/dev/delta/dot.yaml
+++ b/dev/delta/dot.yaml
@@ -1,0 +1,2 @@
+darwin:
+  installs: $DOTFILES_DIR/dev/brew/brew-install-idempotent git-delta

--- a/terminal/nvim/dot.yaml
+++ b/terminal/nvim/dot.yaml
@@ -24,3 +24,4 @@ linux|darwin:
     lua/plugins/which-key.lua: ~/.config/nvim/lua/plugins/which-key.lua
     lua/plugins/mason-auto-update.lua: ~/.config/nvim/lua/plugins/mason-auto-update.lua
     lua/plugins/snacks-picker.lua: ~/.config/nvim/lua/plugins/snacks-picker.lua
+    lua/plugins/branch-diff.lua: ~/.config/nvim/lua/plugins/branch-diff.lua

--- a/terminal/nvim/lua/plugins/branch-diff.lua
+++ b/terminal/nvim/lua/plugins/branch-diff.lua
@@ -1,0 +1,47 @@
+-- Branch diff file picker: browse files changed between current branch and base.
+-- Uses fzf-lua to list `git diff --name-only` against the merge-base.
+
+return {
+  "ibhagwan/fzf-lua",
+  optional = true,
+  keys = {
+    {
+      "<leader>bg",
+      function()
+        local fzf = require("fzf-lua")
+
+        -- Detect base branch: upstream tracking target, or fall back to main/master
+        local function get_base_branch()
+          -- Try the upstream of the current branch (e.g. origin/main)
+          local upstream = vim.fn.systemlist("git rev-parse --abbrev-ref @{upstream} 2>/dev/null")[1]
+          if upstream and upstream ~= "" and not upstream:match("^fatal") then
+            return upstream
+          end
+          -- Fall back to origin HEAD (usually main)
+          local origin_head = vim.fn.systemlist("git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null")[1]
+          if origin_head and origin_head ~= "" and not origin_head:match("^fatal") then
+            return origin_head:gsub("^refs/remotes/", "")
+          end
+          return "origin/main"
+        end
+
+        local base = get_base_branch()
+        local merge_base = vim.fn.systemlist("git merge-base HEAD " .. base)[1]
+        if not merge_base or merge_base == "" then
+          vim.notify("Could not find merge-base with " .. base, vim.log.levels.WARN)
+          return
+        end
+
+        local git_root = vim.fn.systemlist("git rev-parse --show-toplevel")[1]
+
+        fzf.fzf_exec("git diff --name-only " .. merge_base, {
+          prompt = "Branch changes (" .. base .. ")❯ ",
+          cwd = git_root,
+          preview = "git diff " .. merge_base .. " -- " .. git_root .. "/{} | delta --line-numbers 2>/dev/null || git diff " .. merge_base .. " -- " .. git_root .. "/{}",
+          actions = fzf.defaults.actions.files,
+        })
+      end,
+      desc = "Changed files (branch diff)",
+    },
+  },
+}


### PR DESCRIPTION
Adds `<leader>bg` in neovim to browse files changed on the current branch vs its base, with delta-powered diff preview in fzf-lua.

### Changes

- **`terminal/nvim/lua/plugins/branch-diff.lua`** — fzf-lua picker that runs `git diff --name-only` against the merge-base, with `delta --line-numbers` preview. Auto-detects upstream branch, falls back to `origin/main`.
- **`dev/delta/dot.yaml`** — adds `git-delta` as a brew-managed dependency.
- **`terminal/nvim/dot.yaml`** — links the new plugin via punch.